### PR TITLE
Fix (doc): Type 'number' is not assignable to type '25'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const redis = new Redis() as any;
 
 const jsonCache = new JSONCache<{
   name: string;
-  age: 25;
+  age: number;
   address: {
     doorNo: string;
     locality: string;


### PR DESCRIPTION
Argument of type '{ name: string; age: number; address: { doorNo: string; locality: string; pincode: number; }; cars: string[]; }' is not assignable to parameter of type '{ name: string; age: 25; address: { doorNo: string; locality: string; pincode: number; }; }'.
  Types of property 'age' are incompatible.
    Type 'number' is not assignable to type '25' ts(2345)