### PR TITLE
fixes hex string as key 

### DIFF
--- a/src/utils/key.ts
+++ b/src/utils/key.ts
@@ -11,7 +11,7 @@
 export function parseKey(key: string): string | number {
   const numKey = Number(key);
 
-  return isNaN(numKey) ? decodeKey(key) : numKey;
+  return isNaN(numKey) || isHex(key) ? decodeKey(key) : numKey;
 }
 
 /**
@@ -48,3 +48,12 @@ export const splitKey = (() => {
     return key.split(keySplitReg);
   };
 })();
+
+/**
+ * Checks the key is hex string or not.
+ *
+ * @param key
+ */
+ function isHex(key: string): boolean {
+    return key ? Boolean(key.match(/^0x[0-9a-f]+$/i)) : false;
+  }

--- a/test/utils/key.spec.ts
+++ b/test/utils/key.spec.ts
@@ -22,6 +22,11 @@ describe('#utils/key', () => {
       const key = 'helloworld';
       expect(parseKey(key)).to.be.eql('helloworld');
     });
+
+    it('should return the given key as a string, if the key is a hex string', () => {
+        const key = '0x1a2b3c';
+        expect(parseKey(key)).to.be.eql('0x1a2b3c');
+      });
   });
 
   describe('#encodeKey', () => {


### PR DESCRIPTION
# Fixed the problem: Hex string as key
- If JSON data having Hex String as key is set then while getting the data the key was treated as number and array was returned.
E.g.: If `{ '0xa': 'something' }`  was set then it returns `[ null, null, null, null, null, null, null, null, null, null, "something" ]`

